### PR TITLE
Set CAII as default model provider

### DIFF
--- a/app/client/src/pages/DataGenerator/DataGenerator.tsx
+++ b/app/client/src/pages/DataGenerator/DataGenerator.tsx
@@ -15,7 +15,7 @@ import Examples from './Examples';
 import Summary from './Summary';
 import Finish from './Finish';
 
-import { DataGenWizardSteps, WizardStepConfig, WorkflowType } from './types';
+import { DataGenWizardSteps, WizardStepConfig, WorkflowType, ModelProviders } from './types';
 import { WizardCtx } from './utils';
 
 const { Content } = Layout;
@@ -122,7 +122,11 @@ const DataGenerator = () => {
     }
 
 
-    const formData = useRef(initialData || { num_questions: 20, topics: [] });
+    const formData = useRef(initialData || {
+        num_questions: 20,
+        topics: [],
+        inference_type: ModelProviders.CAII,
+    });
 
     const [form] = Form.useForm<FormInstance>();
 

--- a/app/client/src/pages/Evaluator/EvaluateDataset.tsx
+++ b/app/client/src/pages/Evaluator/EvaluateDataset.tsx
@@ -56,7 +56,7 @@ const StyledCard = styled(Card)`
 
 
 const EvaluateDataset: React.FC<Props> = ({ form, loading, modelsMap, dataset, examples, viewType, onEvaluate, evaluate }) => {
-  const inference_type = get(dataset, 'inference_type', '');
+  const inference_type = get(dataset, 'inference_type', ModelProviders.CAII);
   const [models, setModels] = useState<string[]>(get(modelsMap, inference_type, []));
   const selectedInferenceType = Form.useWatch('inference_type', form);
   
@@ -77,8 +77,8 @@ const EvaluateDataset: React.FC<Props> = ({ form, loading, modelsMap, dataset, e
 
   }, [selectedInferenceType]);
 
-  const initialValues = {};
-  if(evaluate && evaluate?.model_parameters) {
+  const initialValues: any = { inference_type };
+  if (evaluate && evaluate?.model_parameters) {
     initialValues.model_parameters = evaluate?.model_parameters;
   }
 


### PR DESCRIPTION
## Summary
- make Cloudera AI Inference Service the default model provider for generation
- set Cloudera AI Inference Service as default in evaluation forms

## Testing
- `pytest -q` *(fails: unrecognized arguments)*
- `npm test --silent` *(fails: vitest not found)*