### PR TITLE
Show custom prompt generator always

### DIFF
--- a/app/client/src/pages/DataGenerator/CustomPromptButton.tsx
+++ b/app/client/src/pages/DataGenerator/CustomPromptButton.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
 import { LoadingOutlined } from '@ant-design/icons';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import { fetchCustomPrompt, fetchPrompt } from "./hooks";
 import Loading from "../Evaluator/Loading";
 
@@ -64,7 +65,11 @@ const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_en
 
   return (
     <>
-      <Button onClick={() => setShowModal(true)} style={{ marginLeft: '8px' }}>Generate Custom Prompt</Button>
+      <Button
+        onClick={() => setShowModal(true)}
+        style={{ marginLeft: '8px' }}
+        icon={<AutoAwesomeIcon />}
+      />
       {showModal && 
         (
             <Modal

--- a/app/client/src/pages/DataGenerator/DataGenerator.tsx
+++ b/app/client/src/pages/DataGenerator/DataGenerator.tsx
@@ -15,7 +15,7 @@ import Examples from './Examples';
 import Summary from './Summary';
 import Finish from './Finish';
 
-import { DataGenWizardSteps, WizardStepConfig, WorkflowType } from './types';
+import { DataGenWizardSteps, WizardStepConfig, WorkflowType, ModelProviders } from './types';
 import { WizardCtx } from './utils';
 
 const { Content } = Layout;
@@ -122,7 +122,11 @@ const DataGenerator = () => {
     }
 
 
-    const formData = useRef(initialData || { num_questions: 20, topics: [] });
+    const formData = useRef(initialData || {
+        num_questions: 20,
+        topics: [],
+        inference_type: ModelProviders.CAII,
+    });
 
     const [form] = Form.useForm<FormInstance>();
 

--- a/app/client/src/pages/DataGenerator/Prompt.tsx
+++ b/app/client/src/pages/DataGenerator/Prompt.tsx
@@ -191,12 +191,21 @@ const Prompt = () => {
                         <StyledFormItem
                             name='custom_prompt'
                             label={
-                                <FormLabel level={4}>
-                                    <Space>
-                                        <>{'Prompt'}</>
-                                        <TooltipIcon message={'Enter a prompt to describe your dataset'}/>
-                                    </Space>
-                                </FormLabel>
+                                <Flex align='center'>
+                                    <FormLabel level={4}>
+                                        <Space>
+                                            <>{'Prompt'}</>
+                                            <TooltipIcon message={'Enter a prompt to describe your dataset'}/>
+                                        </Space>
+                                    </FormLabel>
+                                    <CustomPromptButton
+                                        model_id={model_id}
+                                        inference_type={inference_type}
+                                        caii_endpoint={caii_endpoint}
+                                        use_case={useCase}
+                                        setPrompt={setPrompt}
+                                    />
+                                </Flex>
                             }
                             labelCol={{ span: 24 }}
                             wrapperCol={{ span: 24 }}
@@ -230,16 +239,6 @@ const Prompt = () => {
                         >
                             {'Restore'}
                         </RestoreDefaultBtn>
-                        {(form.getFieldValue('use_case') === Usecases.CUSTOM.toLowerCase() ||
-                            workflow_type === WorkflowType.CUSTOM_DATA_GENERATION) &&  
-                            <CustomPromptButton 
-                                model_id={model_id}
-                                inference_type={inference_type}
-                                caii_endpoint={caii_endpoint}
-                                use_case={useCase}
-                                setPrompt={setPrompt}
-                            />
-                        }
                     </div>
                     {((workflow_type === WorkflowType.CUSTOM_DATA_GENERATION && !isEmpty(doc_paths)) ||
                     (workflow_type === WorkflowType.SUPERVISED_FINE_TUNING && !isEmpty(doc_paths))) && 

--- a/app/client/src/pages/Evaluator/EvaluateDataset.tsx
+++ b/app/client/src/pages/Evaluator/EvaluateDataset.tsx
@@ -56,7 +56,7 @@ const StyledCard = styled(Card)`
 
 
 const EvaluateDataset: React.FC<Props> = ({ form, loading, modelsMap, dataset, examples, viewType, onEvaluate, evaluate }) => {
-  const inference_type = get(dataset, 'inference_type', '');
+  const inference_type = get(dataset, 'inference_type', ModelProviders.CAII);
   const [models, setModels] = useState<string[]>(get(modelsMap, inference_type, []));
   const selectedInferenceType = Form.useWatch('inference_type', form);
   
@@ -77,8 +77,8 @@ const EvaluateDataset: React.FC<Props> = ({ form, loading, modelsMap, dataset, e
 
   }, [selectedInferenceType]);
 
-  const initialValues = {};
-  if(evaluate && evaluate?.model_parameters) {
+  const initialValues: any = { inference_type };
+  if (evaluate && evaluate?.model_parameters) {
     initialValues.model_parameters = evaluate?.model_parameters;
   }
 

--- a/app/client/src/pages/Home/DatasetsTab.tsx
+++ b/app/client/src/pages/Home/DatasetsTab.tsx
@@ -11,6 +11,8 @@ import DateTime from '../../components/DateTime/DateTime';
 import DatasetActions from './DatasetActions';
 import { sortItemsByKey } from '../../utils/sortutils';
 import { SyntheticEvent, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { getFilesURL } from '../Evaluator/util';
 import DatasetExportModal, { ExportResult } from '../../components/Export/ExportModal';
 import React from 'react';
 import { JobStatus } from '../../types';
@@ -111,12 +113,25 @@ const DatasetsTab: React.FC = () => {
             title: 'Display Name',
             dataIndex: 'display_name',
             sorter: sortItemsByKey('display_name'),
+            render: (display_name, record: Dataset) => (
+                <Tooltip title={display_name}>
+                    <Link to={`/dataset/${record.generate_file_name}`}> 
+                        <StyledParagraph style={{ width: 200, marginBottom: 0 }} ellipsis={{ rows: 1 }}>{display_name}</StyledParagraph>
+                    </Link>
+                </Tooltip>
+            )
         }, {
             key: 'generate_file_name',
             title: 'Dataset Name',
             dataIndex: 'generate_file_name',
             sorter: sortItemsByKey('generate_file_name'),
-            render: (generate_file_name) => <Tooltip title={generate_file_name}><StyledParagraph style={{ width: 200, marginBottom: 0 }} ellipsis={{ rows: 1 }}>{generate_file_name}</StyledParagraph></Tooltip>
+            render: (_, record: Dataset) => (
+                <Tooltip title={record.generate_file_name}>
+                    <a target="_blank" rel="noopener noreferrer" href={`${getFilesURL(record.local_export_path)}`}> 
+                        <StyledParagraph style={{ width: 200, marginBottom: 0 }} ellipsis={{ rows: 1 }}>{record.generate_file_name}</StyledParagraph>
+                    </a>
+                </Tooltip>
+            )
         }, {
             key: 'model_id',
             title: 'Model',


### PR DESCRIPTION
## Summary
- always render the CustomPromptButton next to the Prompt heading
- remove the old conditional rendering block

## Testing
- `pytest -q -o addopts=''` *(fails: ModuleNotFoundError: No module named 'boto3')*